### PR TITLE
Add Linux Tool for EBS Auto-Labeling

### DIFF
--- a/AutoTag.sh
+++ b/AutoTag.sh
@@ -8,7 +8,12 @@
 INSTANCEINFO="http://169.254.169.254/latest/dynamic/instance-identity/document/"
 INSTANCEID=$(curl -sL ${INSTANCEINFO} | awk '/instanceId/{print $3}' | \
              sed -e 's/",$//' -e 's/"//')
+AWS_DEFAULT_REGION=$(curl -sL ${INSTANCEINFO} | \
+                     awk '/region/{print $3}' | \
+                     sed -e 's/",$//' -e 's/"//')
 PVS=/sbin/pvs
+
+export AWS_DEFAULT_REGION
 
 # Check your privilege...
 function AmRoot() {

--- a/AutoTag.sh
+++ b/AutoTag.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+#
+# This script is designed to make it easy to capture useful 
+# information about attached EBS volumes and save that 
+# information to the volumes' tag-sets
+# 
+#################################################################
+INSTANCEINFO="http://169.254.169.254/latest/dynamic/instance-identity/document/"
+INSTANCEID=$(curl -sL ${INSTANCEINFO} | awk '/instanceId/{print $3}' | \
+             sed -e 's/",$//' -e 's/"//')
+PVS=/sbin/pvs
+
+# Check your privilege...
+function AmRoot() {
+   if [ $(whoami) = "root" ]
+   then
+      echo "Running with privileges"
+   else
+      echo "Insufficient privileges. Aborting..." > /dev/stderr
+      exit 1
+   fi
+}
+
+# Got LVM?
+function CkHaveLVM() {
+   if [[ $(rpm --quiet -q lvm2)$? -eq 0 ]] && [[ -x ${PVS} ]]
+   then
+      local HAVELVM=TRUE
+   else
+      local HAVELVM=FALSE
+   fi
+
+   echo ${HAVELVM}
+}
+
+# Return list of attached EBS Volume-IDs
+function GetAWSvolIds(){
+   local VOLIDS=($(aws ec2 describe-instances --instance-id=${INSTANCEID}\
+                 --query "Reservations[].Instances[].BlockDeviceMappings[].Ebs[].VolumeId" \
+                 --out text))
+
+   echo "${VOLIDS[@]}"
+}
+
+# Map attached EBS Volume-ID to sdX device-node
+function MapVolIdToDsk(){
+   local VOLID="${1}"
+   local DEVMAP=$(aws ec2 describe-volumes --volume-id=${VOLID} \
+                  --query="Volumes[].Attachments[].Device[]" --out text | \
+                  sed 's/[0-9]*$//')
+
+   echo "${DEVMAP}"
+}
+
+# Tack on LVM group-associations where appropriate
+function AddLVM2Map(){
+   local EBSMAPARR=("${!1}")
+   local LVMMAPARR=("${!2}")
+
+echo ${LVMMAPARR[@]}
+
+   local LOOPC=0
+   while [[ ${LOOPC} -le ${#LVMMAPARR[@]} ]]
+   do
+      local SRCHTOK=$(echo ${LVMMAPARR[${LOOPC}]} | cut -d ":" -f 1)
+
+      # This bit of ugliness avoids array re-iteration...
+      EBSMAPARR=("${EBSMAPARR[@]/${SRCHTOK}/${LVMMAPARR[${LOOPC}]}}")
+
+      local LOOPC=$((${LOOPC} + 1))
+   done
+
+
+   echo ${EBSMAPARR[@]}
+}
+
+# Tag-up the EBSes
+function TagYerIt(){
+   local MAPPING=("${!1}")
+
+   local LOOPC=0
+   while [[ ${LOOPC} -le ${#MAPPING[@]} ]]
+   do
+      local VOLID=$(echo ${MAPPING[${LOOPC}]} | cut -d ":" -f 1)
+      local DEVNODE=$(echo ${MAPPING[${LOOPC}]} | cut -d ":" -f 2)
+      local LVMGRP=$(echo ${MAPPING[${LOOPC}]} | cut -d ":" -f 3)
+
+      if [ "${LVMGRP}" = "" ]
+      then
+         LVMGRP="(none)"
+      fi
+
+      printf "Tagging EBS Volume ${VOLID}... "
+      aws ec2 create-tags --resources ${VOLID} --tags \
+         "Key=Owning Instance,Value=${INSTANCEID}" \
+         "Key=Attachment Point,Value=${DEVNODE}" \
+         "Key=LVM Group,Value=${LVMGRP}" \
+         && echo "Done." || echo "Failed."
+   done
+}
+
+
+#######################
+## Main program flow
+#######################
+
+AmRoot
+
+printf "Determining attached EBS volume IDs... "
+EBSVOLIDS=$(GetAWSvolIds) && echo "Done." || echo "Failed."
+
+printf "Mapping EBS volume IDs to local devices... "
+LOOP=0
+for EBSVOL in ${EBSVOLIDS}
+do
+   EBSDEV=$(MapVolIdToDsk ${EBSVOL})
+   EBSMAP[${LOOP}]="${EBSVOL}:${EBSDEV}"
+   LOOP=$((${LOOP} + 1))
+done  && echo "Done." || echo "Failed."
+
+if [ "$(CkHaveLVM)" = "TRUE" ]
+then
+   echo "Looking for LVM object... "
+   LVOBJ=($(${PVS} --noheadings -o pv_name,vg_name --separator ':' | sed 's/[0-9]*:/:/'))
+
+   echo "Updating EBS/device mappings"
+   MAPPINGS=($(AddLVM2Map "EBSMAP[@]" "LVOBJ[@]"))
+else
+   LVOBJ=""
+   MAPPINGS=(${EBSMAP[@]})
+fi
+
+TagYerIt "MAPPINGS[@]"


### PR DESCRIPTION
Some tenants have had recovery-issues due to failing to capture recovery configuration data. The Linux script included in this PR sets the following tags on EBSes associated to an LxEBSbackup-enabled Linux host:
* `Owning Instance`: Instance-ID of the system the EBS is attached to
* `Attachment Point`: AWS-level EBS attachment-point to the instance being backed up
* ` LVM Group`: Any (OS-level) LVM group associations for the EBS volume.

**Note:** While the `Attachment Point` tag is *usually* reflective of where the instance-OS will see the EBS, instance-configuration may make this a not 100% reliable AWS-to-host device-mapping