### PR TITLE
Adds injection of userData to recovery-instance

### DIFF
--- a/Extras/Reconstitute.py
+++ b/Extras/Reconstitute.py
@@ -1,5 +1,6 @@
 #!/bin/env python
 import boto3
+import base64
 import getopt
 import sys
 import time
@@ -283,7 +284,7 @@ def getConnectInfo(instanceId):
     return
 
 
-#
+# Attach security-groups to recovery-instance
 def addAccess(instanceId,securityGroups):
     secGrpList = securityGroups.split(',')
 
@@ -303,6 +304,40 @@ def addAccess(instanceId,securityGroups):
         print('List of security-groups too long. Skipping')
 
     return
+
+
+# Inject userData into recovery-instance
+def injectUserdata(recoveryHostInstanceId, snapAttribs):
+
+    # Fetch userData from original Instance
+    try:
+        origInstanceId = snapAttribs[next(iter(snapAttribs))]['Source Instance Id']
+
+        # Get userdata from original EC2
+        userDataB64 = ec2client.describe_instance_attribute(
+                       Attribute='userData',
+                       InstanceId=origInstanceId
+                   )['UserData']['Value']
+
+        # Decode the userData
+        userDataTxt = base64.b64decode(userDataB64)
+
+    except:
+        print('Unable to determine source instance-Id from snapshot attributes')
+
+    # Push userdata to recovery EC2
+    try:
+        modedEc2 = ec2client.modify_instance_attribute(
+                       InstanceId=recoveryHostInstanceId,
+                       UserData={
+                           'Value': userDataTxt
+                       },
+                   )
+    except:
+        sys.exit('Failed to set userData on recovery-instance')
+
+    return
+
 
 
 # Make our connections to the service
@@ -338,7 +373,7 @@ cmdopts.add_option(
             action="store_true",
             dest="recovery_power",
             default=False,
-            help="Power on the recovered instance"
+            help="Power on the recovered instance (Default: %default)"
     )
 cmdopts.add_option(
         "-n", "--recovery-hostname",
@@ -375,6 +410,19 @@ cmdopts.add_option(
             dest="recovery_instance_type",
             help="Instance-type to use for recovery-instance (Default: %default)",
             type="string"
+    )
+cmdopts.add_option(
+        "-U", "--user-data-file",
+            action="store",
+            dest="userdata_file",
+            help="Inject userData from selected file"
+    )
+cmdopts.add_option(
+        "-u", "--user-data-clone",
+            action="store_true",
+            default=False,
+            dest="userdata_bool",
+            help="Attempt to clone userData from source instance (Default: %default)"
     )
 cmdopts.add_option(
         "-x", "--access-groups",
@@ -432,6 +480,8 @@ snapSearchTag = options.search_tag
 snapSearchVal = options.search_string
 snapEc2IdTag = options.original_ec2_tag
 snapDevTag = options.original_device_tag
+userDataBool = options.userdata_bool
+userDataFile = options.userdata_file
 
 
 # Surface snapshots' tags
@@ -473,6 +523,14 @@ reattachVolumes(recoveryHostInstanceId,restoredEbsInfo)
 # Attach security-groups to instance
 if securityGroups:
     addAccess(recoveryHostInstanceId,securityGroups)
+
+# Inject userData from file if requested
+if userDataFile:
+    print('', end='')
+
+# Inject cloned userData if requested
+if userDataBool:
+    injectUserdata(recoveryHostInstanceId, snapAttribs)
 
 # Start recovery-instance if requested
 if powerOn:

--- a/Extras/Reconstitute.py
+++ b/Extras/Reconstitute.py
@@ -504,6 +504,10 @@ snapDevTag = options.original_device_tag
 userDataBool = options.userdata_bool
 userDataFile = options.userdata_file
 
+# Handle mutually-exclusive options
+if userDataBool is not False and userDataFile is not False:
+    sys.exit('ERROR: `-u` and `-U` are mutually-exclusive options')
+
 # Test file-access early so we can save some time/effort
 if userDataFile:
     userDataContent = getUserData(userDataFile)

--- a/Extras/Reconstitute.py
+++ b/Extras/Reconstitute.py
@@ -319,6 +319,23 @@ def getUserData(userDataFile):
     return fileContent
 
 
+# Inject recovery-userData into recovery-instance
+def injectUserdata(recoveryHostInstanceId, userDataContent):
+
+    # Push userdata to recovery EC2
+    try:
+        modedEc2 = ec2client.modify_instance_attribute(
+                       InstanceId=recoveryHostInstanceId,
+                       UserData={
+                           'Value': userDataContent
+                       },
+                   )
+    except:
+        sys.exit('Failed to set userData on recovery-instance')
+
+    return
+
+
 # Copy userData from source-instance to recovery-instance
 def cloneUserdata(recoveryHostInstanceId, snapAttribs):
 
@@ -339,32 +356,7 @@ def cloneUserdata(recoveryHostInstanceId, snapAttribs):
         print('Unable to determine source instance-Id from snapshot attributes')
 
     # Push userdata to recovery EC2
-    try:
-        modedEc2 = ec2client.modify_instance_attribute(
-                       InstanceId=recoveryHostInstanceId,
-                       UserData={
-                           'Value': userDataTxt
-                       },
-                   )
-    except:
-        sys.exit('Failed to set userData on recovery-instance')
-
-    return
-
-
-# Inject recovery-userData into recovery-instance
-def injectUserdata(recoveryHostInstanceId, userDataContent):
-
-    # Push userdata to recovery EC2
-    try:
-        modedEc2 = ec2client.modify_instance_attribute(
-                       InstanceId=recoveryHostInstanceId,
-                       UserData={
-                           'Value': userDataContent
-                       },
-                   )
-    except:
-        sys.exit('Failed to set userData on recovery-instance')
+    injectUserdata(recoveryHostInstanceId, userDataTxt)
 
     return
 

--- a/Extras/Reconstitute.py
+++ b/Extras/Reconstitute.py
@@ -306,8 +306,8 @@ def addAccess(instanceId,securityGroups):
     return
 
 
-# Inject userData into recovery-instance
-def injectUserdata(recoveryHostInstanceId, snapAttribs):
+# Copy userData from source-instance to recovery-instance
+def cloneUserdata(recoveryHostInstanceId, snapAttribs):
 
     # Fetch userData from original Instance
     try:
@@ -530,7 +530,7 @@ if userDataFile:
 
 # Inject cloned userData if requested
 if userDataBool:
-    injectUserdata(recoveryHostInstanceId, snapAttribs)
+    cloneUserdata(recoveryHostInstanceId, snapAttribs)
 
 # Start recovery-instance if requested
 if powerOn:


### PR DESCRIPTION
Facilitate instance-recovery by injecting userData into recovery-instance (currently, only tested to work properly with Linux instances that are enabled with `cloud-init`)

- User may specify an external file cotaining valid userData to inject (no linting of file contents will be done)
- User may request that userData be cloned from source instance

Closes #35 